### PR TITLE
Add analytics page with charts for smoking records

### DIFF
--- a/vue-app/package-lock.json
+++ b/vue-app/package-lock.json
@@ -8,8 +8,10 @@
       "name": "vue-app",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "pinia": "^3.0.3",
         "vue": "^3.5.17",
+        "vue-chartjs": "^5.3.2",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -1174,6 +1176,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -2261,6 +2269,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -4449,6 +4469,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-component-type-helpers": {

--- a/vue-app/package.json
+++ b/vue-app/package.json
@@ -12,8 +12,10 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
+    "vue-chartjs": "^5.3.2",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -7,6 +7,7 @@ import { RouterLink, RouterView } from 'vue-router'
     <h1>喫煙記録アプリ</h1>
     <nav>
       <RouterLink to="/">記録</RouterLink>
+      <RouterLink to="/analytics">分析</RouterLink>
       <RouterLink to="/about">設定</RouterLink>
     </nav>
   </header>

--- a/vue-app/src/app/router/index.ts
+++ b/vue-app/src/app/router/index.ts
@@ -12,10 +12,12 @@ const router = createRouter({
     {
       path: '/about',
       name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
       component: () => import('../../pages/AboutView.vue'),
+    },
+    {
+      path: '/analytics',
+      name: 'analytics',
+      component: () => import('../../pages/analytics/ui/AnalyticsPage.vue'),
     },
   ],
 })

--- a/vue-app/src/features/analytics/api/index.ts
+++ b/vue-app/src/features/analytics/api/index.ts
@@ -1,0 +1,1 @@
+export { useAnalytics } from './use-analytics'

--- a/vue-app/src/features/analytics/api/use-analytics.ts
+++ b/vue-app/src/features/analytics/api/use-analytics.ts
@@ -1,0 +1,155 @@
+import { ref, computed, onMounted } from 'vue'
+import { AnalyticsService } from '../model/analytics-service'
+import { SmokingRecordService } from '../../smoking-record/model/smoking-record-service'
+import type { ChartData } from '../model/types'
+import type { ChartOptions } from 'chart.js'
+
+export function useAnalytics() {
+  const isLoading = ref(false)
+  const service = ref<AnalyticsService | null>(null)
+
+  // 統計データ
+  const stats = computed(() => {
+    if (!service.value) return { todayCount: 0, weekCount: 0, monthCount: 0 }
+    return service.value.getStats()
+  })
+
+  // 日別グラフデータ（過去30日）
+  const dailyChartData = computed((): ChartData => {
+    if (!service.value) {
+      return {
+        labels: [],
+        datasets: []
+      }
+    }
+
+    const dailyData = service.value.getDailyData(30)
+    
+    return {
+      labels: dailyData.map(data => {
+        const d = new Date(data.date)
+        return `${d.getMonth() + 1}/${d.getDate()}`
+      }),
+      datasets: [{
+        label: '喫煙本数',
+        data: dailyData.map(data => data.count),
+        borderColor: '#f56565',
+        backgroundColor: 'rgba(245, 101, 101, 0.1)',
+        tension: 0.4,
+        fill: true
+      }]
+    }
+  })
+
+  // 時間別グラフデータ
+  const hourlyChartData = computed((): ChartData => {
+    if (!service.value) {
+      return {
+        labels: [],
+        datasets: []
+      }
+    }
+
+    const hourlyData = service.value.getHourlyData()
+    
+    return {
+      labels: Array.from({ length: 24 }, (_, i) => `${i}時`),
+      datasets: [{
+        label: '喫煙回数',
+        data: hourlyData.map(data => data.count),
+        backgroundColor: 'rgba(72, 187, 120, 0.6)',
+        borderColor: '#48bb78',
+        borderWidth: 1
+      }]
+    }
+  })
+
+  // 月別グラフデータ
+  const monthlyChartData = computed((): ChartData => {
+    if (!service.value) {
+      return {
+        labels: [],
+        datasets: []
+      }
+    }
+
+    const monthlyData = service.value.getMonthlyData(12)
+    
+    return {
+      labels: monthlyData.map(data => {
+        const [year, month] = data.month.split('-')
+        return `${year}/${month}`
+      }),
+      datasets: [{
+        label: '月間喫煙本数',
+        data: monthlyData.map(data => data.count),
+        borderColor: '#4299e1',
+        backgroundColor: 'rgba(66, 153, 225, 0.1)',
+        tension: 0.4,
+        fill: true
+      }]
+    }
+  })
+
+  // チャートオプション
+  const chartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false
+      }
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          stepSize: 1
+        }
+      }
+    }
+  }
+
+  const hourlyChartOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false
+      }
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          stepSize: 1
+        }
+      }
+    }
+  }
+
+  const loadData = async () => {
+    isLoading.value = true
+    try {
+      const records = SmokingRecordService.getAll()
+      service.value = new AnalyticsService(records)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  onMounted(() => {
+    loadData()
+  })
+
+  return {
+    isLoading,
+    stats,
+    dailyChartData,
+    hourlyChartData,
+    monthlyChartData,
+    chartOptions,
+    hourlyChartOptions,
+    loadData
+  }
+}

--- a/vue-app/src/features/analytics/index.ts
+++ b/vue-app/src/features/analytics/index.ts
@@ -1,0 +1,10 @@
+export { useAnalytics } from './api'
+export { AnalyticsService } from './model/analytics-service'
+export type { 
+  AnalyticsStats, 
+  DailyData, 
+  HourlyData, 
+  MonthlyData, 
+  ChartData, 
+  ChartDataset 
+} from './model/types'

--- a/vue-app/src/features/analytics/model/analytics-service.test.ts
+++ b/vue-app/src/features/analytics/model/analytics-service.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { AnalyticsService } from './analytics-service'
+import type { SmokingRecord } from '../../smoking-record'
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService
+  let mockRecords: SmokingRecord[]
+
+  beforeEach(() => {
+    const now = new Date('2024-01-15T12:00:00Z')
+    mockRecords = [
+      { id: '1', timestamp: new Date('2024-01-15T10:00:00Z') }, // 今日
+      { id: '2', timestamp: new Date('2024-01-15T14:00:00Z') }, // 今日
+      { id: '3', timestamp: new Date('2024-01-14T10:00:00Z') }, // 昨日 (1日前)
+      { id: '4', timestamp: new Date('2024-01-10T10:00:00Z') }, // 5日前
+      { id: '5', timestamp: new Date('2023-12-15T10:00:00Z') }, // 1ヶ月前 (31日前)
+    ]
+    service = new AnalyticsService(mockRecords, now)
+  })
+
+  describe('getStats', () => {
+    test('今日、今週、今月の統計を正しく計算する', () => {
+      const stats = service.getStats()
+      
+      expect(stats.todayCount).toBe(2) // 今日の記録: 2件
+      expect(stats.weekCount).toBe(4) // 今週の記録: 4件（今日2件 + 昨日1件 + 5日前1件）
+      expect(stats.monthCount).toBe(4) // 今月の記録: 4件（1ヶ月前を除く）
+    })
+  })
+
+  describe('getDailyData', () => {
+    test('指定日数分の日別データを生成する', () => {
+      const dailyData = service.getDailyData(3)
+      
+      expect(dailyData).toHaveLength(3)
+      expect(dailyData[0].date).toBe('2024-01-13')
+      expect(dailyData[0].count).toBe(0)
+      expect(dailyData[1].date).toBe('2024-01-14')
+      expect(dailyData[1].count).toBe(1)
+      expect(dailyData[2].date).toBe('2024-01-15')
+      expect(dailyData[2].count).toBe(2)
+    })
+
+    test('記録がない日は0を返す', () => {
+      const dailyData = service.getDailyData(3)
+      const noRecordDay = dailyData.find(d => d.date === '2024-01-13')
+      
+      expect(noRecordDay).toBeDefined()
+      expect(noRecordDay!.count).toBe(0)
+    })
+  })
+
+  describe('getHourlyData', () => {
+    test('24時間分の時間別データを生成する', () => {
+      const hourlyData = service.getHourlyData()
+      
+      expect(hourlyData).toHaveLength(24)
+      
+      // 実際の時間データを確認
+      const totalCount = hourlyData.reduce((sum, h) => sum + h.count, 0)
+      expect(totalCount).toBe(mockRecords.length)
+      
+      // 19時台（UTC10時→JST19時）に記録があることを確認
+      expect(hourlyData[19].count).toBe(4)
+      // 23時台（UTC14時→JST23時）に記録があることを確認
+      expect(hourlyData[23].count).toBe(1)
+      // 0時台は記録なし
+      expect(hourlyData[0].count).toBe(0)
+    })
+  })
+
+  describe('getMonthlyData', () => {
+    test('指定月数分の月別データを生成する', () => {
+      const monthlyData = service.getMonthlyData(2)
+      
+      expect(monthlyData).toHaveLength(2)
+      expect(monthlyData[0].month).toBe('2023-12')
+      expect(monthlyData[0].count).toBe(1)
+      expect(monthlyData[1].month).toBe('2024-01')
+      expect(monthlyData[1].count).toBe(4)
+    })
+  })
+})

--- a/vue-app/src/features/analytics/model/analytics-service.ts
+++ b/vue-app/src/features/analytics/model/analytics-service.ts
@@ -1,0 +1,107 @@
+import type { SmokingRecord } from '../../smoking-record'
+import type { AnalyticsStats, DailyData, HourlyData, MonthlyData, AnalyticsService as IAnalyticsService } from './types'
+
+export class AnalyticsService implements IAnalyticsService {
+  constructor(
+    private records: SmokingRecord[],
+    private currentDate: Date = new Date()
+  ) {}
+
+  getStats(): AnalyticsStats {
+    const today = new Date(this.currentDate)
+    today.setHours(0, 0, 0, 0)
+    
+    const weekAgo = new Date(this.currentDate)
+    weekAgo.setDate(weekAgo.getDate() - 7)
+    weekAgo.setHours(0, 0, 0, 0)
+    
+    const monthAgo = new Date(this.currentDate)
+    monthAgo.setDate(monthAgo.getDate() - 30)
+    monthAgo.setHours(0, 0, 0, 0)
+
+    const todayCount = this.records.filter(record => {
+      const recordDate = new Date(record.timestamp)
+      recordDate.setHours(0, 0, 0, 0)
+      return recordDate.getTime() === today.getTime()
+    }).length
+
+    const weekCount = this.records.filter(record => 
+      record.timestamp >= weekAgo
+    ).length
+
+    const monthCount = this.records.filter(record => 
+      record.timestamp >= monthAgo
+    ).length
+
+    return { todayCount, weekCount, monthCount }
+  }
+
+  getDailyData(days: number): DailyData[] {
+    const daily = new Map<string, number>()
+    const result: DailyData[] = []
+    
+    // 指定日数分の日付を生成
+    for (let i = days - 1; i >= 0; i--) {
+      const date = new Date(this.currentDate)
+      date.setDate(date.getDate() - i)
+      const dateStr = date.toISOString().split('T')[0]
+      daily.set(dateStr, 0)
+      result.push({ date: dateStr, count: 0 })
+    }
+    
+    // 記録をカウント
+    this.records.forEach(record => {
+      const dateStr = record.timestamp.toISOString().split('T')[0]
+      if (daily.has(dateStr)) {
+        daily.set(dateStr, daily.get(dateStr)! + 1)
+      }
+    })
+    
+    // カウントを反映
+    result.forEach((item, index) => {
+      item.count = daily.get(item.date) || 0
+    })
+    
+    return result
+  }
+
+  getHourlyData(): HourlyData[] {
+    const hourly = new Array(24).fill(0)
+    
+    this.records.forEach(record => {
+      const hour = record.timestamp.getHours()
+      hourly[hour]++
+    })
+    
+    return hourly.map((count, hour) => ({ hour, count }))
+  }
+
+  getMonthlyData(months: number): MonthlyData[] {
+    const monthly = new Map<string, number>()
+    const result: MonthlyData[] = []
+    
+    // 指定月数分の月を生成
+    for (let i = months - 1; i >= 0; i--) {
+      const date = new Date(this.currentDate)
+      date.setMonth(date.getMonth() - i)
+      const monthStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+      monthly.set(monthStr, 0)
+      result.push({ month: monthStr, count: 0 })
+    }
+    
+    // 記録をカウント
+    this.records.forEach(record => {
+      const monthStr = `${record.timestamp.getFullYear()}-${String(record.timestamp.getMonth() + 1).padStart(2, '0')}`
+      if (monthly.has(monthStr)) {
+        monthly.set(monthStr, monthly.get(monthStr)! + 1)
+      }
+    })
+    
+    // カウントを反映
+    result.forEach((item, index) => {
+      item.count = monthly.get(item.month) || 0
+    })
+    
+    return result
+  }
+}

--- a/vue-app/src/features/analytics/model/types.ts
+++ b/vue-app/src/features/analytics/model/types.ts
@@ -1,0 +1,44 @@
+import type { SmokingRecord } from '../../smoking-record'
+
+export interface AnalyticsStats {
+  todayCount: number
+  weekCount: number
+  monthCount: number
+}
+
+export interface DailyData {
+  date: string
+  count: number
+}
+
+export interface HourlyData {
+  hour: number
+  count: number
+}
+
+export interface MonthlyData {
+  month: string
+  count: number
+}
+
+export interface ChartDataset {
+  label: string
+  data: number[]
+  borderColor?: string
+  backgroundColor?: string
+  tension?: number
+  fill?: boolean
+  borderWidth?: number
+}
+
+export interface ChartData {
+  labels: string[]
+  datasets: ChartDataset[]
+}
+
+export interface AnalyticsService {
+  getStats(): AnalyticsStats
+  getDailyData(days: number): DailyData[]
+  getHourlyData(): HourlyData[]
+  getMonthlyData(months: number): MonthlyData[]
+}

--- a/vue-app/src/pages/analytics/index.ts
+++ b/vue-app/src/pages/analytics/index.ts
@@ -1,0 +1,1 @@
+export { default as AnalyticsPage } from './ui/AnalyticsPage.vue'

--- a/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
+++ b/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
@@ -1,3 +1,47 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Line, Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js'
+import { useAnalytics } from '../../../features/analytics'
+
+// Chart.js コンポーネントを登録
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+)
+
+const {
+  isLoading,
+  stats,
+  dailyChartData,
+  hourlyChartData,
+  monthlyChartData,
+  chartOptions,
+  hourlyChartOptions
+} = useAnalytics()
+
+// 統計データの展開
+const todayCount = computed(() => stats.value.todayCount)
+const weekCount = computed(() => stats.value.weekCount)
+const monthCount = computed(() => stats.value.monthCount)
+</script>
+
 <template>
   <div class="analytics-page">
     <header class="analytics-header">
@@ -48,49 +92,7 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import { computed } from 'vue'
-import { Line, Bar } from 'vue-chartjs'
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  BarElement,
-  Title,
-  Tooltip,
-  Legend
-} from 'chart.js'
-import { useAnalytics } from '../../../features/analytics'
 
-// Chart.js コンポーネントを登録
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  BarElement,
-  Title,
-  Tooltip,
-  Legend
-)
-
-const {
-  isLoading,
-  stats,
-  dailyChartData,
-  hourlyChartData,
-  monthlyChartData,
-  chartOptions,
-  hourlyChartOptions
-} = useAnalytics()
-
-// 統計データの展開
-const todayCount = computed(() => stats.value.todayCount)
-const weekCount = computed(() => stats.value.weekCount)
-const monthCount = computed(() => stats.value.monthCount)
-</script>
 
 <style scoped>
 .analytics-page {

--- a/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
+++ b/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
@@ -1,0 +1,388 @@
+<template>
+  <div class="analytics-page">
+    <header class="analytics-header">
+      <h1 class="analytics-title">分析</h1>
+    </header>
+
+    <main class="analytics-content">
+      <!-- 今日の統計 -->
+      <section class="stat-cards">
+        <div class="stat-card">
+          <h3 class="stat-title">今日</h3>
+          <p class="stat-value">{{ todayCount }}本</p>
+        </div>
+        <div class="stat-card">
+          <h3 class="stat-title">今週</h3>
+          <p class="stat-value">{{ weekCount }}本</p>
+        </div>
+        <div class="stat-card">
+          <h3 class="stat-title">今月</h3>
+          <p class="stat-value">{{ monthCount }}本</p>
+        </div>
+      </section>
+
+      <!-- 日別グラフ -->
+      <section class="chart-section">
+        <h2 class="chart-title">日別推移（過去30日）</h2>
+        <div class="chart-container">
+          <Line :data="dailyChartData" :options="chartOptions" />
+        </div>
+      </section>
+
+      <!-- 時間別グラフ -->
+      <section class="chart-section">
+        <h2 class="chart-title">時間別分布</h2>
+        <div class="chart-container">
+          <Bar :data="hourlyChartData" :options="hourlyChartOptions" />
+        </div>
+      </section>
+
+      <!-- 月別グラフ -->
+      <section class="chart-section">
+        <h2 class="chart-title">月別推移</h2>
+        <div class="chart-container">
+          <Line :data="monthlyChartData" :options="chartOptions" />
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { Line, Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  type ChartOptions
+} from 'chart.js'
+import { SmokingRecordManager, type SmokingRecord } from '@/entities/smoking-record'
+
+// Chart.js コンポーネントを登録
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+)
+
+const records = ref<SmokingRecord[]>([])
+
+// 統計データ
+const todayCount = computed(() => {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  
+  return records.value.filter(record => {
+    const recordDate = new Date(record.timestamp)
+    recordDate.setHours(0, 0, 0, 0)
+    return recordDate.getTime() === today.getTime()
+  }).length
+})
+
+const weekCount = computed(() => {
+  const weekAgo = new Date()
+  weekAgo.setDate(weekAgo.getDate() - 7)
+  weekAgo.setHours(0, 0, 0, 0)
+  
+  return records.value.filter(record => 
+    record.timestamp >= weekAgo
+  ).length
+})
+
+const monthCount = computed(() => {
+  const monthAgo = new Date()
+  monthAgo.setDate(monthAgo.getDate() - 30)
+  monthAgo.setHours(0, 0, 0, 0)
+  
+  return records.value.filter(record => 
+    record.timestamp >= monthAgo
+  ).length
+})
+
+// 日別データ（過去30日）
+const dailyChartData = computed(() => {
+  const daily = new Map<string, number>()
+  const last30Days = []
+  
+  // 過去30日の日付を生成
+  for (let i = 29; i >= 0; i--) {
+    const date = new Date()
+    date.setDate(date.getDate() - i)
+    const dateStr = date.toISOString().split('T')[0]
+    daily.set(dateStr, 0)
+    last30Days.push(dateStr)
+  }
+  
+  // 記録をカウント
+  records.value.forEach(record => {
+    const dateStr = record.timestamp.toISOString().split('T')[0]
+    if (daily.has(dateStr)) {
+      daily.set(dateStr, daily.get(dateStr)! + 1)
+    }
+  })
+  
+  return {
+    labels: last30Days.map(date => {
+      const d = new Date(date)
+      return `${d.getMonth() + 1}/${d.getDate()}`
+    }),
+    datasets: [{
+      label: '喫煙本数',
+      data: last30Days.map(date => daily.get(date) || 0),
+      borderColor: '#f56565',
+      backgroundColor: 'rgba(245, 101, 101, 0.1)',
+      tension: 0.4,
+      fill: true
+    }]
+  }
+})
+
+// 時間別データ
+const hourlyChartData = computed(() => {
+  const hourly = new Array(24).fill(0)
+  
+  records.value.forEach(record => {
+    const hour = record.timestamp.getHours()
+    hourly[hour]++
+  })
+  
+  return {
+    labels: Array.from({ length: 24 }, (_, i) => `${i}時`),
+    datasets: [{
+      label: '喫煙回数',
+      data: hourly,
+      backgroundColor: 'rgba(72, 187, 120, 0.6)',
+      borderColor: '#48bb78',
+      borderWidth: 1
+    }]
+  }
+})
+
+// 月別データ
+const monthlyChartData = computed(() => {
+  const monthly = new Map<string, number>()
+  
+  // 過去12ヶ月を生成
+  const last12Months = []
+  for (let i = 11; i >= 0; i--) {
+    const date = new Date()
+    date.setMonth(date.getMonth() - i)
+    const monthStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+    monthly.set(monthStr, 0)
+    last12Months.push(monthStr)
+  }
+  
+  // 記録をカウント
+  records.value.forEach(record => {
+    const monthStr = `${record.timestamp.getFullYear()}-${String(record.timestamp.getMonth() + 1).padStart(2, '0')}`
+    if (monthly.has(monthStr)) {
+      monthly.set(monthStr, monthly.get(monthStr)! + 1)
+    }
+  })
+  
+  return {
+    labels: last12Months.map(month => {
+      const [year, m] = month.split('-')
+      return `${year}/${m}`
+    }),
+    datasets: [{
+      label: '月間喫煙本数',
+      data: last12Months.map(month => monthly.get(month) || 0),
+      borderColor: '#4299e1',
+      backgroundColor: 'rgba(66, 153, 225, 0.1)',
+      tension: 0.4,
+      fill: true
+    }]
+  }
+})
+
+// チャートオプション
+const chartOptions: ChartOptions<'line'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false
+    }
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      ticks: {
+        stepSize: 1
+      }
+    }
+  }
+}
+
+const hourlyChartOptions: ChartOptions<'bar'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false
+    }
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      ticks: {
+        stepSize: 1
+      }
+    }
+  }
+}
+
+onMounted(() => {
+  records.value = SmokingRecordManager.getAll()
+})
+</script>
+
+<style scoped>
+.analytics-page {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 1rem;
+}
+
+.analytics-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.analytics-title {
+  color: white;
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.analytics-content {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* 統計カード */
+.stat-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem 1rem;
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.stat-title {
+  font-size: 0.875rem;
+  color: #666;
+  margin: 0 0 0.5rem 0;
+  font-weight: 500;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2d3748;
+  margin: 0;
+}
+
+/* チャートセクション */
+.chart-section {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.chart-title {
+  font-size: 1.125rem;
+  color: #2d3748;
+  margin: 0 0 1.5rem 0;
+  font-weight: 600;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+  width: 100%;
+}
+
+/* スマホ対応 */
+@media (max-width: 768px) {
+  .analytics-page {
+    padding: 0.5rem;
+  }
+  
+  .analytics-title {
+    font-size: 1.5rem;
+  }
+  
+  .stat-cards {
+    gap: 0.75rem;
+  }
+  
+  .stat-card {
+    padding: 1rem 0.75rem;
+  }
+  
+  .stat-value {
+    font-size: 1.25rem;
+  }
+  
+  .chart-section {
+    padding: 1rem;
+    margin-bottom: 1rem;
+  }
+  
+  .chart-title {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+  }
+  
+  .chart-container {
+    height: 200px;
+  }
+}
+
+@media (max-width: 480px) {
+  .stat-cards {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+  }
+  
+  .stat-card {
+    padding: 0.75rem 0.5rem;
+  }
+  
+  .stat-title {
+    font-size: 0.75rem;
+  }
+  
+  .stat-value {
+    font-size: 1.125rem;
+  }
+  
+  .chart-container {
+    height: 180px;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- 喫煙記録の分析画面を追加
- Chart.jsを使用した複数のグラフィカル分析機能を実装
- スマホ対応のレスポンシブデザイン

### 機能詳細
- **統計カード**: 今日/今週/今月の喫煙本数を表示
- **日別推移グラフ**: 過去30日間の日別喫煙本数をライングラフで表示
- **時間別分布グラフ**: 時間別の喫煙パターンをバーグラフで表示  
- **月別推移グラフ**: 過去12ヶ月の月別推移をライングラフで表示

### 技術的変更
- Chart.js & vue-chartjs の依存関係追加
- 新しいルート `/analytics` を追加
- レスポンシブ対応（480px、768px でのブレークポイント）
- TypeScript 型安全性を確保

## Test plan
- [ ] 分析ページが正常に表示されること
- [ ] 各グラフが適切にデータを表示すること
- [ ] スマホでのレスポンシブ表示が正常に動作すること
- [ ] ナビゲーションから分析ページにアクセスできること

🤖 Generated with [Claude Code](https://claude.ai/code)