### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,0 +1,65 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: vue-app/package-lock.json
+        
+    - name: Install dependencies
+      run: |
+        cd vue-app
+        npm ci
+        
+    - name: Type check
+      run: |
+        cd vue-app
+        npm run type-check
+        
+    - name: Build
+      run: |
+        cd vue-app
+        npm run build
+        
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+      
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: vue-app/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vue-app/public/404.html
+++ b/vue-app/public/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vue App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/vue-app/vite.config.ts
+++ b/vue-app/vite.config.ts
@@ -15,4 +15,5 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  base: process.env.NODE_ENV === 'production' ? '/suilog/' : '/',
 })


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated deployment to GitHub Pages
- Configure build process for Vue.js application in vue-app directory  
- Set up proper permissions and environment for Pages deployment

## Test plan
- [ ] Verify workflow file syntax and structure
- [ ] Test build process locally with `cd vue-app && npm run build`
- [ ] Merge PR and confirm GitHub Pages deployment works
- [ ] Verify deployed site accessibility and functionality

🤖 Generated with [Claude Code](https://claude.ai/code)