### PR TITLE
Add settings page with daily and monthly goals tracking

### DIFF
--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -19,7 +19,7 @@ import { RouterLink, RouterView } from 'vue-router'
         分析
       </RouterLink>
       <RouterLink 
-        to="/about" 
+        to="/settings" 
         class="px-4 py-2 no-underline text-gray-600 rounded transition-colors duration-200 hover:bg-gray-200 router-link-exact-active:bg-blue-600 router-link-exact-active:text-white"
       >
         設定

--- a/vue-app/src/app/router/index.ts
+++ b/vue-app/src/app/router/index.ts
@@ -19,6 +19,11 @@ const router = createRouter({
       name: 'analytics',
       component: () => import('../../pages/analytics/ui/AnalyticsPage.vue'),
     },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: () => import('../../pages/settings/ui/SettingsPage.vue'),
+    },
   ],
 })
 

--- a/vue-app/src/features/settings/api/index.ts
+++ b/vue-app/src/features/settings/api/index.ts
@@ -1,0 +1,1 @@
+export { useSettings } from './use-settings'

--- a/vue-app/src/features/settings/api/use-settings.ts
+++ b/vue-app/src/features/settings/api/use-settings.ts
@@ -1,0 +1,83 @@
+import { reactive, computed } from 'vue'
+import { settingsService } from '../model/settings-service'
+import type { SettingsData, SettingsState } from '../model/types'
+
+export function useSettings() {
+  const state = reactive<SettingsState>({
+    data: settingsService.loadSettings(),
+    errors: {},
+    isLoading: false,
+    isSaved: false
+  })
+
+  const savedData = computed(() => {
+    const saved = settingsService.loadSettings()
+    return saved
+  })
+
+  const updateField = <K extends keyof SettingsData>(field: K, value: SettingsData[K]) => {
+    state.data[field] = value
+    
+    // リアルタイムバリデーション
+    const fieldErrors = settingsService.validateSettings({ [field]: value })
+    if (fieldErrors[field]) {
+      state.errors[field] = fieldErrors[field]
+    } else {
+      delete state.errors[field]
+    }
+    
+    state.isSaved = false
+  }
+
+  const handleSubmit = async () => {
+    state.isLoading = true
+    state.errors = {}
+
+    // 全体バリデーション
+    const validationErrors = settingsService.validateSettings(state.data)
+    
+    if (Object.keys(validationErrors).length > 0) {
+      state.errors = validationErrors
+      state.isLoading = false
+      return
+    }
+
+    try {
+      // 設定を保存
+      settingsService.saveSettings(state.data)
+      state.isSaved = true
+      
+      // 成功メッセージを一定時間後に非表示
+      setTimeout(() => {
+        state.isSaved = false
+      }, 3000)
+      
+    } catch (error) {
+      console.error('Settings save error:', error)
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  const resetToDefaults = () => {
+    state.data = settingsService.getDefaultSettings()
+    state.errors = {}
+    state.isSaved = false
+  }
+
+  const clearData = () => {
+    settingsService.clearSettings()
+    state.data = settingsService.getDefaultSettings()
+    state.errors = {}
+    state.isSaved = false
+  }
+
+  return {
+    state,
+    savedData,
+    updateField,
+    handleSubmit,
+    resetToDefaults,
+    clearData
+  }
+}

--- a/vue-app/src/features/settings/index.ts
+++ b/vue-app/src/features/settings/index.ts
@@ -1,0 +1,3 @@
+export * from './api'
+export * from './model/types'
+export { settingsService } from './model/settings-service'

--- a/vue-app/src/features/settings/model/settings-service.ts
+++ b/vue-app/src/features/settings/model/settings-service.ts
@@ -1,0 +1,50 @@
+import { localStorageService } from '../../../shared/lib/storage'
+import type { SettingsData } from './types'
+
+export class SettingsService {
+  private readonly STORAGE_KEY = 'settings'
+
+  getDefaultSettings(): SettingsData {
+    return {
+      dailyGoal: 20, // デフォルト：一日20本
+      monthlyBudgetGoal: 15000 // デフォルト：一ヶ月15,000円
+    }
+  }
+
+  saveSettings(settings: SettingsData): void {
+    localStorageService.set(this.STORAGE_KEY, settings)
+  }
+
+  loadSettings(): SettingsData {
+    const savedSettings = localStorageService.get<SettingsData>(this.STORAGE_KEY)
+    return savedSettings || this.getDefaultSettings()
+  }
+
+  clearSettings(): void {
+    localStorageService.remove(this.STORAGE_KEY)
+  }
+
+  validateSettings(settings: Partial<SettingsData>): Partial<Record<keyof SettingsData, string>> {
+    const errors: Partial<Record<keyof SettingsData, string>> = {}
+
+    if (settings.dailyGoal !== undefined) {
+      if (settings.dailyGoal <= 0) {
+        errors.dailyGoal = '一日の目標本数は1本以上で入力してください'
+      } else if (settings.dailyGoal > 100) {
+        errors.dailyGoal = '一日の目標本数は100本以下で入力してください'
+      }
+    }
+
+    if (settings.monthlyBudgetGoal !== undefined) {
+      if (settings.monthlyBudgetGoal <= 0) {
+        errors.monthlyBudgetGoal = '月間予算は1円以上で入力してください'
+      } else if (settings.monthlyBudgetGoal > 1000000) {
+        errors.monthlyBudgetGoal = '月間予算は100万円以下で入力してください'
+      }
+    }
+
+    return errors
+  }
+}
+
+export const settingsService = new SettingsService()

--- a/vue-app/src/features/settings/model/types.ts
+++ b/vue-app/src/features/settings/model/types.ts
@@ -1,0 +1,11 @@
+export interface SettingsData {
+  dailyGoal: number // 一日の目標本数
+  monthlyBudgetGoal: number // 一ヶ月の目標金額（円）
+}
+
+export interface SettingsState {
+  data: SettingsData
+  errors: Partial<Record<keyof SettingsData, string>>
+  isLoading: boolean
+  isSaved: boolean
+}

--- a/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
+++ b/vue-app/src/pages/analytics/ui/AnalyticsPage.vue
@@ -13,6 +13,7 @@ import {
   Legend
 } from 'chart.js'
 import { useAnalytics } from '../../../features/analytics'
+import { useSettings } from '../../../features/settings'
 
 // Chart.js コンポーネントを登録
 ChartJS.register(
@@ -36,10 +37,39 @@ const {
   hourlyChartOptions
 } = useAnalytics()
 
+const { savedData: settings } = useSettings()
+
 // 統計データの展開
 const todayCount = computed(() => stats.value.todayCount)
 const weekCount = computed(() => stats.value.weekCount)
 const monthCount = computed(() => stats.value.monthCount)
+
+// 目標達成状況の計算
+const dailyGoalProgress = computed(() => {
+  const dailyGoal = settings.value.dailyGoal
+  const progress = (todayCount.value / dailyGoal) * 100
+  return Math.min(progress, 100)
+})
+
+// 今月の平均と目標の比較
+const monthlyAverage = computed(() => {
+  const today = new Date()
+  const currentDayOfMonth = today.getDate()
+  return currentDayOfMonth > 0 ? Math.round(monthCount.value / currentDayOfMonth) : 0
+})
+
+// 月間予算使用状況の推定（仮想的な計算）
+const estimatedMonthlyCost = computed(() => {
+  // 1本あたり約25円として計算（一般的なタバコ価格から推定）
+  const costPerCigarette = 25
+  return monthCount.value * costPerCigarette
+})
+
+const monthlyBudgetProgress = computed(() => {
+  const budget = settings.value.monthlyBudgetGoal
+  const progress = (estimatedMonthlyCost.value / budget) * 100
+  return progress
+})
 </script>
 
 <template>
@@ -54,6 +84,16 @@ const monthCount = computed(() => stats.value.monthCount)
         <div class="bg-white rounded-xl p-6 text-center shadow-lg">
           <h3 class="text-sm text-gray-600 mb-2 font-medium">今日</h3>
           <p class="text-2xl font-bold text-gray-800 m-0">{{ todayCount }}本</p>
+          <div class="mt-2">
+            <div class="text-xs text-gray-500">目標: {{ settings.dailyGoal }}本</div>
+            <div class="w-full bg-gray-200 rounded-full h-1.5 mt-1">
+              <div 
+                class="h-1.5 rounded-full transition-all duration-300"
+                :class="dailyGoalProgress >= 100 ? 'bg-green-600' : 'bg-orange-600'"
+                :style="{ width: dailyGoalProgress + '%' }"
+              ></div>
+            </div>
+          </div>
         </div>
         <div class="bg-white rounded-xl p-6 text-center shadow-lg">
           <h3 class="text-sm text-gray-600 mb-2 font-medium">今週</h3>
@@ -62,6 +102,67 @@ const monthCount = computed(() => stats.value.monthCount)
         <div class="bg-white rounded-xl p-6 text-center shadow-lg">
           <h3 class="text-sm text-gray-600 mb-2 font-medium">今月</h3>
           <p class="text-2xl font-bold text-gray-800 m-0">{{ monthCount }}本</p>
+          <div class="text-xs text-gray-500 mt-1">
+            日平均: {{ monthlyAverage }}本
+          </div>
+        </div>
+      </section>
+
+      <!-- 目標達成状況 -->
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <!-- 日別目標 -->
+        <div class="bg-white rounded-xl p-6 shadow-lg">
+          <h3 class="text-lg font-semibold text-gray-800 mb-4">日別目標達成状況</h3>
+          <div class="space-y-3">
+            <div class="flex justify-between items-center">
+              <span class="text-sm text-gray-600">今日の進捗</span>
+              <span class="text-sm font-medium" :class="dailyGoalProgress >= 100 ? 'text-green-600' : 'text-orange-600'">
+                {{ Math.round(dailyGoalProgress) }}%
+              </span>
+            </div>
+            <div class="w-full bg-gray-200 rounded-full h-3">
+              <div 
+                class="h-3 rounded-full transition-all duration-300"
+                :class="dailyGoalProgress >= 100 ? 'bg-green-600' : 'bg-orange-600'"
+                :style="{ width: Math.min(dailyGoalProgress, 100) + '%' }"
+              ></div>
+            </div>
+            <div class="text-sm text-gray-600">
+              {{ todayCount }}/{{ settings.dailyGoal }}本
+              <span v-if="dailyGoalProgress >= 100" class="text-green-600 font-medium">
+                （目標達成！）
+              </span>
+              <span v-else class="text-gray-500">
+                （あと{{ settings.dailyGoal - todayCount }}本）
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 月間予算 -->
+        <div class="bg-white rounded-xl p-6 shadow-lg">
+          <h3 class="text-lg font-semibold text-gray-800 mb-4">月間予算使用状況</h3>
+          <div class="space-y-3">
+            <div class="flex justify-between items-center">
+              <span class="text-sm text-gray-600">予算使用率</span>
+              <span class="text-sm font-medium" :class="monthlyBudgetProgress >= 100 ? 'text-red-600' : monthlyBudgetProgress >= 80 ? 'text-orange-600' : 'text-green-600'">
+                {{ Math.round(monthlyBudgetProgress) }}%
+              </span>
+            </div>
+            <div class="w-full bg-gray-200 rounded-full h-3">
+              <div 
+                class="h-3 rounded-full transition-all duration-300"
+                :class="monthlyBudgetProgress >= 100 ? 'bg-red-600' : monthlyBudgetProgress >= 80 ? 'bg-orange-600' : 'bg-green-600'"
+                :style="{ width: Math.min(monthlyBudgetProgress, 100) + '%' }"
+              ></div>
+            </div>
+            <div class="text-sm text-gray-600">
+              {{ estimatedMonthlyCost.toLocaleString() }}/{{ settings.monthlyBudgetGoal.toLocaleString() }}円
+              <div class="text-xs text-gray-500 mt-1">
+                ※1本25円で計算した推定値
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/vue-app/src/pages/settings/index.ts
+++ b/vue-app/src/pages/settings/index.ts
@@ -1,0 +1,1 @@
+export * from './ui'

--- a/vue-app/src/pages/settings/ui/SettingsPage.vue
+++ b/vue-app/src/pages/settings/ui/SettingsPage.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { useSettings } from '../../../features/settings'
+
+const {
+  state,
+  savedData,
+  updateField,
+  handleSubmit,
+  resetToDefaults
+} = useSettings()
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto p-6">
+    <h1 class="text-3xl font-bold text-gray-900 mb-8">設定</h1>
+    
+    <div class="bg-white shadow-sm rounded-lg p-6">
+      <h2 class="text-xl font-semibold text-gray-800 mb-6">目標設定</h2>
+      
+      <form @submit.prevent="handleSubmit" class="space-y-6">
+        <!-- 一日の目標本数 -->
+        <div>
+          <label for="dailyGoal" class="block text-sm font-medium text-gray-700 mb-2">
+            一日の目標本数
+          </label>
+          <div class="relative">
+            <input 
+              id="dailyGoal" 
+              :value="state.data.dailyGoal"
+              @input="updateField('dailyGoal', parseInt(($event.target as HTMLInputElement).value) || 0)"
+              type="number"
+              min="1"
+              max="100"
+              placeholder="20"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            <span class="absolute right-3 top-2 text-gray-500 text-sm">本</span>
+          </div>
+          <span v-if="state.errors.dailyGoal" class="text-red-600 text-sm mt-1 block">
+            {{ state.errors.dailyGoal }}
+          </span>
+          <p class="text-gray-500 text-sm mt-1">
+            一日あたりの喫煙目標本数を設定してください（1-100本）
+          </p>
+        </div>
+        
+        <!-- 一ヶ月の目標金額 -->
+        <div>
+          <label for="monthlyBudgetGoal" class="block text-sm font-medium text-gray-700 mb-2">
+            月間予算目標
+          </label>
+          <div class="relative">
+            <input 
+              id="monthlyBudgetGoal" 
+              :value="state.data.monthlyBudgetGoal"
+              @input="updateField('monthlyBudgetGoal', parseInt(($event.target as HTMLInputElement).value) || 0)"
+              type="number"
+              min="1"
+              max="1000000"
+              placeholder="15000"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            <span class="absolute right-3 top-2 text-gray-500 text-sm">円</span>
+          </div>
+          <span v-if="state.errors.monthlyBudgetGoal" class="text-red-600 text-sm mt-1 block">
+            {{ state.errors.monthlyBudgetGoal }}
+          </span>
+          <p class="text-gray-500 text-sm mt-1">
+            一ヶ月あたりのタバコ代予算を設定してください（1-1,000,000円）
+          </p>
+        </div>
+        
+        <!-- 成功メッセージ -->
+        <div v-if="state.isSaved" class="bg-green-50 border border-green-200 rounded-md p-4">
+          <div class="flex">
+            <div class="text-green-800">
+              <p class="text-sm">設定が保存されました！</p>
+            </div>
+          </div>
+        </div>
+        
+        <!-- ボタン -->
+        <div class="flex space-x-4 pt-4">
+          <button 
+            type="submit" 
+            :disabled="state.isLoading"
+            class="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {{ state.isLoading ? '保存中...' : '設定を保存' }}
+          </button>
+          
+          <button 
+            type="button"
+            @click="resetToDefaults"
+            class="bg-gray-600 text-white px-6 py-2 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+          >
+            デフォルトに戻す
+          </button>
+        </div>
+      </form>
+    </div>
+    
+    <!-- 現在の設定表示 -->
+    <div class="bg-gray-50 shadow-sm rounded-lg p-6 mt-6">
+      <h3 class="text-lg font-semibold text-gray-800 mb-4">現在の設定</h3>
+      <div class="space-y-2">
+        <p class="text-gray-700">
+          <span class="font-medium">一日の目標本数:</span> {{ savedData.dailyGoal }}本
+        </p>
+        <p class="text-gray-700">
+          <span class="font-medium">月間予算目標:</span> {{ savedData.monthlyBudgetGoal.toLocaleString() }}円
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/vue-app/src/pages/settings/ui/index.ts
+++ b/vue-app/src/pages/settings/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsPage } from './SettingsPage.vue'

--- a/vue-app/src/pages/smoking/ui/SmokingRecordPage.vue
+++ b/vue-app/src/pages/smoking/ui/SmokingRecordPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useSmokingRecord } from '../../../features/smoking-record'
+import { useSettings } from '../../../features/settings'
 
 const {
   recentRecords,
@@ -10,6 +12,32 @@ const {
   handleAddRecord,
   handleDeleteRecord
 } = useSmokingRecord()
+
+const { savedData: settings } = useSettings()
+
+// 目標達成状況の計算
+const goalProgress = computed(() => {
+  const dailyGoal = settings.value.dailyGoal
+  const progress = (todayCount.value / dailyGoal) * 100
+  return Math.min(progress, 100)
+})
+
+const goalStatus = computed(() => {
+  const remaining = settings.value.dailyGoal - todayCount.value
+  if (remaining <= 0) {
+    return {
+      type: 'achieved',
+      message: '今日の目標を達成しました！',
+      color: 'text-green-600'
+    }
+  } else {
+    return {
+      type: 'remaining',
+      message: `目標まであと${remaining}本`,
+      color: 'text-orange-600'
+    }
+  }
+})
 </script>
 
 <template>
@@ -17,6 +45,29 @@ const {
     <div class="text-center bg-gray-50 p-8 rounded-lg mb-8">
       <h2 class="text-gray-800 mb-0">今日の喫煙記録</h2>
       <div class="text-5xl font-bold text-red-600 mt-4">{{ todayCount }}本</div>
+      
+      <!-- 目標達成状況 -->
+      <div class="mt-6">
+        <div class="flex justify-between items-center mb-2">
+          <span class="text-sm text-gray-600">目標: {{ settings.dailyGoal }}本</span>
+          <span class="text-sm font-medium" :class="goalStatus.color">
+            {{ goalStatus.message }}
+          </span>
+        </div>
+        
+        <!-- プログレスバー -->
+        <div class="w-full bg-gray-200 rounded-full h-2.5">
+          <div 
+            class="h-2.5 rounded-full transition-all duration-300"
+            :class="goalStatus.type === 'achieved' ? 'bg-green-600' : 'bg-orange-600'"
+            :style="{ width: goalProgress + '%' }"
+          ></div>
+        </div>
+        
+        <div class="text-xs text-gray-500 mt-1">
+          {{ Math.round(goalProgress) }}% 達成
+        </div>
+      </div>
     </div>
 
     <div class="bg-white p-8 rounded-lg shadow-sm mb-8">


### PR DESCRIPTION
## Summary
- Implement comprehensive settings page for goal configuration
- Add real-time goal achievement tracking to existing pages
- Enhance user experience with visual progress indicators

## Features Added
### Settings Page (/settings)
- Daily smoking goal configuration (1-100 cigarettes)
- Monthly budget target setting (1-1,000,000 yen)
- Real-time validation with user-friendly error messages
- Default value restoration functionality
- LocalStorage-based data persistence

### Enhanced Record Page
- Daily goal progress visualization with color-coded progress bars
- Goal achievement status messages
- Remaining cigarettes counter for motivation

### Enhanced Analytics Page
- Detailed daily goal tracking section with percentage completion
- Monthly budget usage monitoring with cost estimation
- Visual indicators using traffic light color scheme (green/orange/red)
- Monthly average cigarette consumption display

## Technical Implementation
- Follows Feature-Sliced Design (FSD) architecture
- Utilizes existing LocalStorageService for data persistence
- Implements proper TypeScript typing throughout
- Reactive Vue 3 Composition API integration
- Comprehensive input validation and error handling

## Test Plan
- [ ] Verify settings page loads correctly at /settings route
- [ ] Test goal configuration with various input values
- [ ] Confirm validation works for edge cases (negative values, very large numbers)
- [ ] Check progress indicators update correctly on record page
- [ ] Validate analytics page displays goal tracking accurately
- [ ] Test data persistence across browser sessions
- [ ] Confirm responsive design works on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)